### PR TITLE
Replace set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: "[Setup 5] Set project version"
         id: get_version
-        run: echo ::set-output name=project_version::$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+        run: echo project_version=$(./gradlew properties -q | grep "version:" | awk '{print $2}') >> $GITHUB_OUTPUT
 
       - name: "[CI] Build, Test, and Package"
         uses: ./.github/actions/ci

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "[Setup 5] Set project version"
         id: get_version
-        run: echo ::set-output name=project_version::$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+        run: echo project_version=$(./gradlew properties -q | grep "version:" | awk '{print $2}') >> $GITHUB_OUTPUT
 
       - name: "[CI] Build, test, and package"
         uses: ./.github/actions/ci


### PR DESCRIPTION
Addresses a deprecation by Github, see issue https://github.com/zowe/zowe-install-packaging/issues/3378 .